### PR TITLE
Cleanup header files

### DIFF
--- a/cbitvector.cpp
+++ b/cbitvector.cpp
@@ -17,6 +17,11 @@
  */
 
 #include "cbitvector.h"
+#include "crypto/crypto.h"
+#include "utils.h"
+#include <algorithm>
+#include <iomanip>
+#include <iostream>
 
 /* Fill random values using the pre-defined AES key */
 void CBitVector::FillRand(uint32_t bits, crypto* crypt) {
@@ -286,7 +291,7 @@ template<class T> void CBitVector::GetBytes(T* dst, T* src, T* lim) {
 //optimized bytewise XOR operation
 void CBitVector::XORBytes(BYTE* p, int pos, int len) {
 	if(pos + len > m_nByteSize)
-	cout << "pos = " << pos << ", len = " << len << ", bytesize = " << m_nByteSize << endl;
+	std::cout << "pos = " << pos << ", len = " << len << ", bytesize = " << m_nByteSize << std::endl;
 	assert(pos + len <= m_nByteSize);
 
 	BYTE* dst = m_pBits + pos;
@@ -392,28 +397,28 @@ void CBitVector::CLShift(uint64_t pos) {
 void CBitVector::Print(int fromBit, int toBit) {
 	int to = toBit > (m_nByteSize << 3) ? (m_nByteSize << 3) : toBit;
 	for (int i = fromBit; i < to; i++) {
-		cout << (unsigned int) GetBitNoMask(i);
+		std::cout << (unsigned int) GetBitNoMask(i);
 	}
-	cout << endl;
+	std::cout << std::endl;
 }
 
 void CBitVector::PrintHex(int fromByte, int toByte, bool linebreak) {
 	int to = toByte > (m_nByteSize) ? (m_nByteSize) : toByte;
 
 	for (int i = fromByte; i < to; i++) {
-		cout << setw(2) << setfill('0') << (hex) << ((unsigned int) m_pBits[i]);
+		std::cout << std::setw(2) << std::setfill('0') << (std::hex) << ((unsigned int) m_pBits[i]);
 	}
 	if(linebreak){
-		cout << (dec) << endl;
+		std::cout << (std::dec) << std::endl;
 	}
 }
 
 void CBitVector::PrintHex(bool linebreak) {
 	for (int i = 0; i < m_nByteSize; i++) {
-		cout << setw(2) << setfill('0') << (hex) << ((unsigned int) m_pBits[i]);
+		std::cout << std::setw(2) << std::setfill('0') << (std::hex) << ((unsigned int) m_pBits[i]);
 	}
 	if(linebreak){
-		cout << (dec) << endl;
+		std::cout << (std::dec) << std::endl;
 	}
 }
 
@@ -421,9 +426,9 @@ void CBitVector::PrintBinaryMasked(int from, int to) {
 	int new_to = to > (m_nByteSize<<3) ? (m_nByteSize<<3) : to;
 
 	for (int i = from; i < new_to; i++) {
-		cout << (unsigned int) GetBit(i);
+		std::cout << (unsigned int) GetBit(i);
 	}
-	cout << endl;
+	std::cout << std::endl;
 }
 
 void CBitVector::PrintContent() {
@@ -433,19 +438,19 @@ void CBitVector::PrintContent() {
 	}
 	if (m_nNumElementsDimB == 1) {
 		for (int i = 0; i < m_nNumElements; i++) {
-			cout << Get<int>(i) << ", ";
+			std::cout << Get<int>(i) << ", ";
 		}
-		cout << endl;
+		std::cout << std::endl;
 	} else {
 		for (int i = 0; i < m_nNumElements; i++) {
-			cout << "(";
+			std::cout << "(";
 			for (int j = 0; j < m_nNumElementsDimB - 1; j++) {
-				cout << Get2D<int>(i, j) << ", ";
+				std::cout << Get2D<int>(i, j) << ", ";
 			}
-			cout << Get2D<int>(i, m_nNumElementsDimB - 1);
-			cout << "), ";
+			std::cout << Get2D<int>(i, m_nNumElementsDimB - 1);
+			std::cout << "), ";
 		}
-		cout << endl;
+		std::cout << std::endl;
 	}
 }
 
@@ -482,10 +487,10 @@ void CBitVector::XOR_no_mask(int p, int bitPos, int bitLen) {
 
 	int i = bitPos >> 3, j = 8 - (bitPos & 0x7), k;
 
-	m_pBits[i++] ^= (GetIntBitsFromLen(p, 0, min(j, bitLen)) << (8 - j)) & 0xFF;
+	m_pBits[i++] ^= (GetIntBitsFromLen(p, 0, std::min(j, bitLen)) << (8 - j)) & 0xFF;
 
 	for (k = bitLen - j; k > 0; k -= 8, i++, j += 8) {
-		m_pBits[i] ^= GetIntBitsFromLen(p, j, min(8, k));
+		m_pBits[i] ^= GetIntBitsFromLen(p, j, std::min(8, k));
 	}
 }
 
@@ -494,7 +499,7 @@ unsigned int CBitVector::GetInt(int bitPos, int bitLen) {
 	assert(bitPos + bitLen <= (m_nByteSize <<3));
 
 	int ret = 0, i = bitPos >> 3, j = (bitPos & 0x7), k;
-	ret = (m_pBits[i++] >> (j)) & (GetMask(min(8, bitLen)));
+	ret = (m_pBits[i++] >> (j)) & (GetMask(std::min(8, bitLen)));
 	if (bitLen == 1)
 		return ret;
 	j = 8 - j;
@@ -535,7 +540,7 @@ void CBitVector::EklundhBitTranspose(int rows, int columns) {
 	lim = (REGISTER_SIZE*) m_pBits + ceil_divide(rows * columns, 8);
 
 	int offset = (columns >> 3) / sizeof(REGISTER_SIZE);
-	int numiters = ceil_log2(min(rows, columns));
+	int numiters = ceil_log2(std::min(rows, columns));
 	int srcidx = 1, destidx;
 	int rounds;
 	int p;

--- a/cbitvector.h
+++ b/cbitvector.h
@@ -20,10 +20,14 @@
 #define CBITVECTOR_H_
 
 #include "typedefs.h"
-#include "crypto/crypto.h"
-#include <math.h>
-#include <iostream>
-#include <iomanip>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+
+// forward declarations
+class crypto;
 
 /** Deprecated. */
 static const BYTE REVERSE_NIBBLE_ORDER[16] = { 0x0, 0x8, 0x4, 0xC, 0x2, 0xA, 0x6, 0xE, 0x1, 0x9, 0x5, 0xD, 0x3, 0xB, 0x7, 0xF };

--- a/channel.h
+++ b/channel.h
@@ -8,10 +8,12 @@
 #ifndef CHANNEL_H_
 #define CHANNEL_H_
 
-#include "typedefs.h"
-#include "socket.h"
 #include "rcvthread.h"
 #include "sndthread.h"
+#include <cassert>
+#include <cstdint>
+#include <cstring>
+#include <queue>
 
 class channel {
 public:

--- a/circular_queue.cpp
+++ b/circular_queue.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "circular_queue.h"
+#include <cstdlib>
 
 CQueue::CQueue(int maxsize) {
 	head = 0;
@@ -24,6 +25,11 @@ CQueue::CQueue(int maxsize) {
 
 	queuesize = maxsize;
 	queue = (int*) malloc(sizeof(int) * queuesize);
+}
+
+CQueue::~CQueue() {
+	if (queue)
+		free(queue);
 }
 
 void CQueue::enq(int ele) {

--- a/circular_queue.h
+++ b/circular_queue.h
@@ -19,7 +19,7 @@
 #ifndef __CQUEUE__
 #define __CQUEUE__
 
-#include "typedefs.h"
+
 class CQueue {
 private:
 	int queuesize;
@@ -28,11 +28,7 @@ private:
 	int* queue;
 public:
 	CQueue(int maxsize);
-	~CQueue() {
-		if (queue)
-			free(queue);
-	}
-	;
+	~CQueue();
 	void enq(int ele);
 	int deq();
 	int size();

--- a/codewords.h
+++ b/codewords.h
@@ -19,7 +19,8 @@
 #ifndef __CODEWORDS_H_
 #define __CODEWORDS_H_
 
-#include "typedefs.h"
+#include <cstdint>
+#include <cstdlib>
 
 static const uint32_t m_nCodewords = 256;
 static const uint32_t m_nCWIntlen = 8;

--- a/connection.cpp
+++ b/connection.cpp
@@ -17,16 +17,19 @@
  */
 
 #include "connection.h"
+#include "socket.h"
+#include <sstream>
+#include <iostream>
 
-BOOL Connect(string address, short port, vector<CSocket*> &sockets, int id) {
+BOOL Connect(std::string address, short port, std::vector<CSocket*> &sockets, int id) {
 	int nNumConnections;
 
 	BOOL bFail = FALSE;
 	LONG lTO = CONNECT_TIMEO_MILISEC;
-	//cout << "Connecting" << endl;
-	ostringstream os;
+	//std::cout << "Connecting" << endl;
+	std::ostringstream os;
 #ifndef BATCH
-	cout << "Connecting party "<< id <<": " << address << ", " << port << endl;
+	std::cout << "Connecting party "<< id <<": " << address << ", " << port << std::endl;
 #endif
 
 	for (int j = 0; j < sockets.size(); j++) {
@@ -39,8 +42,8 @@ BOOL Connect(string address, short port, vector<CSocket*> &sockets, int id) {
 				sockets[j]->Send(&j, sizeof(int));
 #ifndef BATCH
 				os.str("");
-				os << " (" << id << ") (" << j << ") connected" << endl;
-				cout << os.str() << flush;
+				os << " (" << id << ") (" << j << ") connected" << std::endl;
+				std::cout << os.str() << std::flush;
 #endif
 				if (j == sockets.size() - 1) {
 					return TRUE;
@@ -56,29 +59,29 @@ BOOL Connect(string address, short port, vector<CSocket*> &sockets, int id) {
 	connect_failure:
 
 	os.str("");
-	os << " (" << id << ") connection failed due to timeout!" << endl;
-	cout << os.str() << flush;
+	os << " (" << id << ") connection failed due to timeout!\n";
+	std::cout << os.str() << std::flush;
 	return FALSE;
 
 }
 
-BOOL Listen(string address, short port, vector<vector<CSocket*> > &sockets, int numConnections, int myID) {
+BOOL Listen(std::string address, short port, std::vector<std::vector<CSocket*> > &sockets, int numConnections, int myID) {
 	// everybody except the last thread listenes
-	ostringstream os;
+	std::ostringstream os;
 
 #ifndef BATCH
-	cout << "Listening: " << address << ":" << port << endl;
+	std::cout << "Listening: " << address << ":" << port << std::endl;
 #endif
 	if (!sockets[myID][0]->Socket()) {
-		cerr << "Error: a socket could not be created " << endl;
+		std::cerr << "Error: a socket could not be created \n";
 		goto listen_failure;
 	}
 	if (!sockets[myID][0]->Bind(port, address)) {
-		cerr << "Error: a socket could not be bound" << endl;
+		std::cerr << "Error: a socket could not be bound\n";
 		goto listen_failure;
 	}
 	if (!sockets[myID][0]->Listen()) {
-		cerr << "Error: could not listen on the socket " << endl;
+		std::cerr << "Error: could not listen on the socket \n";
 		goto listen_failure;
 	}
 
@@ -86,7 +89,7 @@ BOOL Listen(string address, short port, vector<vector<CSocket*> > &sockets, int 
 			{
 		CSocket sock;
 		if (!sockets[myID][0]->Accept(sock)) {
-			cerr << "Error: could not accept connection" << endl;
+			std::cerr << "Error: could not accept connection\n";
 			goto listen_failure;
 		}
 		// receive initial pid when connected
@@ -109,9 +112,9 @@ BOOL Listen(string address, short port, vector<vector<CSocket*> > &sockets, int 
 
 #ifndef BATCH
 		os.str("");
-		os << " (" << conID <<") (" << conID << ") connection accepted" << endl;
+		os << " (" << conID <<") (" << conID << ") connection accepted\n";
 
-		cout << os.str() << flush;
+		std::cout << os.str() << std::flush;
 #endif
 		// locate the socket appropriately
 		sockets[nID][conID]->AttachFrom(sock);
@@ -119,10 +122,10 @@ BOOL Listen(string address, short port, vector<vector<CSocket*> > &sockets, int 
 	}
 
 #ifndef BATCH
-	cout << "Listening finished" << endl;
+	std::cout << "Listening finished" << std::endl;
 #endif
 	return TRUE;
 
-	listen_failure: cout << "Listen failed" << endl;
+	listen_failure: std::cout << "Listen failed" << std::endl;
 	return FALSE;
 }

--- a/connection.h
+++ b/connection.h
@@ -20,11 +20,13 @@
 #define __CONNECTION_H__
 
 #include "typedefs.h"
-#include "socket.h"
-#include "cbitvector.h"
-#include <sstream>
+#include <string>
+#include <vector>
 
-BOOL Connect(string address, short port, vector<CSocket*> &sockets, int id);
-BOOL Listen(string address, short port, vector<vector<CSocket*> > &sockets, int numConnections, int myID);
+// forward declaration
+class CSocket;
+
+BOOL Connect(std::string address, short port, std::vector<CSocket*> &sockets, int id);
+BOOL Listen(std::string address, short port, std::vector<std::vector<CSocket*> > &sockets, int numConnections, int myID);
 
 #endif

--- a/constants.h
+++ b/constants.h
@@ -20,6 +20,7 @@
 #define _CONSTANTS_H_
 
 #include "typedefs.h"
+#include <cstdint>
 
 #define BATCH
 //#define FIXED_KEY_AES_HASHING

--- a/crypto/crypto.cpp
+++ b/crypto/crypto.cpp
@@ -17,6 +17,11 @@
  */
 
 #include "crypto.h"
+#include <openssl/sha.h>
+#include <openssl/des.h>
+#include "ecc-pk-crypto.h"
+#include "gmp-pk-crypto.h"
+#include <utility>
 
 crypto::crypto(uint32_t symsecbits, uint8_t* seed) {
 	init(symsecbits, seed);
@@ -305,7 +310,7 @@ void crypto::gen_rnd_perm(uint32_t* perm, uint32_t neles) {
 	}
 	for (i = 0; i < neles; i++) {
 		j = rndbuf[i] % neles; //NOT UNIFORM
-		swap(perm[i], perm[j]);
+		std::swap(perm[i], perm[j]);
 	}
 	free(rndbuf);
 }

--- a/crypto/crypto.h
+++ b/crypto/crypto.h
@@ -20,22 +20,11 @@
 #define CRYPTO_H_
 
 #include <openssl/evp.h>
-#include <openssl/sha.h>
-#include <openssl/des.h>
-#include <fstream>
-#include <sys/stat.h>
-#include <fcntl.h>
-#include <iostream>
-#include <iomanip>
-
-#include "../typedefs.h"
 #include "../constants.h"
-#include "gmp-pk-crypto.h"
-#include "ecc-pk-crypto.h"
 #include "../socket.h"
 
-#include "TedKrovetzAesNiWrapperC.h"
-#include "intrin_sequential_enc8.h"
+// forward declarations
+class pk_crypto;
 
 const uint8_t ZERO_IV[AES_BYTES] = { 0 };
 

--- a/crypto/dgk.cpp
+++ b/crypto/dgk.cpp
@@ -24,6 +24,10 @@
  */
 
 #include "dgk.h"
+#include "../powmod.h"
+#include "../utils.h"
+#include <cstdlib>
+#include <cstring>
 
 #define DGK_CHECKSIZE 0
 

--- a/crypto/dgk.h
+++ b/crypto/dgk.h
@@ -26,13 +26,6 @@
 #ifndef _DGK_H_
 #define _DGK_H_
 #include <gmp.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include <time.h>
-#include "../powmod.h"
-#include "../timer.h"
-#include "../utils.h"
 
 /*
  This represents a DGK public key.

--- a/crypto/djn.cpp
+++ b/crypto/djn.cpp
@@ -21,6 +21,9 @@
  */
 
 #include "djn.h"
+#include "../powmod.h"
+#include "../utils.h"
+#include <cstdlib>
 
 #define DJN_DEBUG 0
 #define DJN_CHECKSIZE 0

--- a/crypto/djn.h
+++ b/crypto/djn.h
@@ -23,12 +23,6 @@
 #ifndef _DJN_H_
 #define _DJN_H_
 #include <gmp.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include "../powmod.h"
-#include "../timer.h"
-#include "../utils.h"
 
 /*
  On memory handling:

--- a/crypto/ecc-pk-crypto.cpp
+++ b/crypto/ecc-pk-crypto.cpp
@@ -17,6 +17,9 @@
  */
 
 #include "ecc-pk-crypto.h"
+#include "../miracl_lib/ecn.h"
+#include "../miracl_lib/big.h"
+#include "../miracl_lib/ec2.h"
 
 char *ecx163 = (char *) "2fe13c0537bbc11acaa07d793de4e6d5e5c94eee8";
 char *ecy163 = (char *) "289070fb05d38ff58321f2e800536d538ccdaa3d9";
@@ -252,6 +255,13 @@ bool ecc_fe::eq(fe* a) {
 	return (*val) == (*fe2ec2(a));
 }
 
+void ecc_fe::init() {
+	val = new EC2();
+};
+void ecc_fe::print() {
+	std::cout << (*val) << std::endl;
+};
+
 ecc_num::ecc_num(ecc_field* fld) {
 	field = fld;
 	val = new Big();
@@ -304,16 +314,30 @@ void ecc_num::export_to_bytes(uint8_t* buf, uint32_t field_size_bytes) {
 	big_to_bytes((int32_t) field_size_bytes, val->getbig(), (char*) buf, true);
 }
 
+void ecc_num::print() {
+	std::cout << (*val) << std::endl;
+};
+
 // ecc_brickexp methods
+struct ecc_brickexp::ecc_brickexp_impl {
+	ebrick2 br;
+};
+
 ecc_brickexp::ecc_brickexp(fe* point, ecc_fparams* fparams) {
 	Big x, y;
 	fe2ec2(point)->getxy(x, y);
-	ebrick2_init(&br, x.getbig(), y.getbig(), fparams->BA->getbig(), fparams->BB->getbig(), fparams->m, fparams->a, fparams->b, fparams->c, 8, fparams->secparam);
+	impl = std::make_unique<ecc_brickexp_impl>();
+	ebrick2_init(&impl->br, x.getbig(), y.getbig(), fparams->BA->getbig(), fparams->BB->getbig(), fparams->m, fparams->a, fparams->b, fparams->c, 8, fparams->secparam);
 }
+
+ecc_brickexp::~ecc_brickexp() {
+	ebrick2_end(&impl->br);
+}
+
 
 void ecc_brickexp::pow(fe* result, num* e) {
 	Big xtmp, ytmp;
-	mul2_brick(&br, num2Big(e)->getbig(), xtmp.getbig(), ytmp.getbig());
+	mul2_brick(&impl->br, num2Big(e)->getbig(), xtmp.getbig(), ytmp.getbig());
 	*fe2ec2(result) = EC2(xtmp, ytmp);
 }
 

--- a/crypto/ecc-pk-crypto.h
+++ b/crypto/ecc-pk-crypto.h
@@ -20,10 +20,11 @@
 #define ECC_PK_CRYPTO_H_
 
 #include "pk-crypto.h"
+#include <memory>
 
-#include "../miracl_lib/ecn.h"
-#include "../miracl_lib/big.h"
-#include "../miracl_lib/ec2.h"
+// forward declarations
+class Big;
+class EC2;
 
 #define fe2ec2(fieldele) (((ecc_fe*) (fieldele))->get_val())
 #define num2Big(number) (((ecc_num*) (number))->get_val())
@@ -106,10 +107,7 @@ public:
 	void export_to_bytes(uint8_t* buf, uint32_t field_size_bytes);
 	void import_from_bytes(uint8_t* buf, uint32_t field_size_bytes);
 	void set_rnd(uint32_t bits);
-	void print() {
-		cout << (*val) << endl;
-	}
-	;
+	void print();
 
 private:
 	Big* val;
@@ -133,16 +131,10 @@ public:
 	void sample_fe_from_bytes(uint8_t* buf, uint32_t bytelen);
 	bool eq(fe* a);
 
-	void print() {
-		cout << (*val) << endl;
-	}
-	;
+	void print();
 
 private:
-	void init() {
-		val = new EC2();
-	}
-	;
+	void init();
 	EC2* val;
 	ecc_field* field;
 };
@@ -150,13 +142,12 @@ private:
 class ecc_brickexp: public brickexp {
 public:
 	ecc_brickexp(fe* point, ecc_fparams* fparams);
-	~ecc_brickexp() {
-		ebrick2_end(&br);
-	}
+	~ecc_brickexp();
 
 	void pow(fe* res, num* e);
 private:
-	ebrick2 br;
+	struct ecc_brickexp_impl;	// used to hide MIRACL's ebrick2 type in the implementation
+	std::unique_ptr<ecc_brickexp_impl> impl;
 };
 
 void point_to_byte(uint8_t* pBufIdx, uint32_t field_size_bytes, EC2* to_export);

--- a/fileops.cpp
+++ b/fileops.cpp
@@ -1,4 +1,6 @@
 #include "fileops.h"
+#include <cstdio>
+#include <unistd.h>
 
 
 BOOL FileExists(char *filename) {

--- a/fileops.h
+++ b/fileops.h
@@ -1,7 +1,7 @@
 #ifndef _FILEOPS_H_
 #define _FILEOPS_H_
 
-#include <stdio.h>
+#include <cstdint>
 #include "typedefs.h"
 
 	//TODO move to utils

--- a/graycode.cpp
+++ b/graycode.cpp
@@ -18,8 +18,10 @@
  *                  http://www.gnu.org/licenses/
  ******************************************************************************/
 
-#include <stdio.h>
+#include <cstdio>
+#include <cstdlib>
 #include "graycode.h"
+#include "utils.h"
 
 int gray_code(int number, int length) {
 	int lastbit = 0;

--- a/graycode.h
+++ b/graycode.h
@@ -12,8 +12,6 @@
 #ifndef GRAYCODE_H_
 #define GRAYCODE_H_
 
-#include "typedefs.h"
-#include "utils.h"
 
 /******************************************************************************
  *

--- a/parse_options.cpp
+++ b/parse_options.cpp
@@ -17,6 +17,8 @@
  */
 
 #include "parse_options.h"
+#include <cstring>
+#include <iostream>
 
 /**
  * takes a string in the Format "c i i i ..."

--- a/parse_options.h
+++ b/parse_options.h
@@ -19,11 +19,8 @@
 #ifndef UTIL_PARSE_OPTIONS_H_
 #define UTIL_PARSE_OPTIONS_H_
 
-#include <string.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <iostream>
-#include <stdint.h>
+#include <cstdint>
+#include <string>
 #include <vector>
 
 /**

--- a/powmod.cpp
+++ b/powmod.cpp
@@ -17,8 +17,13 @@
  */
 
 #include "powmod.h"
+#include <cstdlib>
 
 #define POWMOD_DEBUG 0
+
+#if POWMOD_DEBUG
+#include <cstdio>
+#endif
 
 mpz_t* m_table_g;
 mpz_t* m_table_h;

--- a/powmod.h
+++ b/powmod.h
@@ -19,8 +19,6 @@
 #ifndef _POWMOD_H_
 #define _POWMOD_H_
 
-#include <stdio.h>
-#include <stdlib.h>
 #include <gmp.h>
 
 extern mpz_t* m_table_g;

--- a/rcvthread.h
+++ b/rcvthread.h
@@ -8,10 +8,11 @@
 #ifndef RCV_THREAD_H_
 #define RCV_THREAD_H_
 
-#include "typedefs.h"
 #include "constants.h"
 #include "socket.h"
 #include "thread.h"
+#include <cassert>
+#include <queue>
 
 typedef struct {
 	uint8_t *buf;

--- a/sndthread.h
+++ b/sndthread.h
@@ -8,10 +8,11 @@
 #ifndef SND_THREAD_H_
 #define SND_THREAD_H_
 
-#include "typedefs.h"
 #include "constants.h"
 #include "socket.h"
 #include "thread.h"
+#include <cassert>
+#include <queue>
 
 struct snd_task {
 	uint8_t channelid;

--- a/socket.h
+++ b/socket.h
@@ -19,7 +19,38 @@
 #ifndef __SOCKET_H__BY_SGCHOI
 #define __SOCKET_H__BY_SGCHOI
 
+
 #include "typedefs.h"
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+
+// moved here from typedefs.h
+#ifdef WIN32
+#include <WinSock2.h>
+#include <windows.h>
+
+typedef unsigned short USHORT;
+typedef int socklen_t;
+#pragma comment(lib, "wsock32.lib")
+
+#define SleepMiliSec(x)	Sleep(x)
+
+#else //WIN32
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netdb.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include <netinet/tcp.h>
+
+typedef int SOCKET;
+#define INVALID_SOCKET -1
+
+#define SleepMiliSec(x)			usleep((x)<<10)
+#endif //WIN32
+
 
 class CSocket {
 public:

--- a/timer.h
+++ b/timer.h
@@ -22,7 +22,8 @@
 #include <sys/time.h>
 #include <string>
 #include <iostream>
-#include <stdlib.h>
+#include <cstdlib>
+#include <vector>
 #include "socket.h"
 
 #include "typedefs.h"

--- a/typedefs.h
+++ b/typedefs.h
@@ -19,15 +19,6 @@
 #ifndef __TYPEDEFS_H__
 #define __TYPEDEFS_H__
 
-#include <sys/time.h>
-#include <assert.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <cstring>
-#include <string>
-#include <vector>
-#include <iostream>
-
 typedef struct SECURITYLEVELS {
 	int statbits;
 	int symbits;
@@ -101,35 +92,6 @@ T sub(T a, T b, T m) {
 #define MAX_BYTE 0xFF
 #define MAX_UINT MAX_INT
 
-#ifdef WIN32
-#include <WinSock2.h>
-#include <windows.h>
-
-typedef unsigned short USHORT;
-typedef int socklen_t;
-#pragma comment(lib, "wsock32.lib")
-
-#define SleepMiliSec(x)	Sleep(x)
-
-#else //WIN32
-
-#include <sys/types.h>       
-#include <sys/socket.h>      
-#include <netdb.h>           
-#include <arpa/inet.h>       
-#include <unistd.h>          
-#include <netinet/in.h>   
-#include <stdio.h>
-#include <stdlib.h>
-#include <errno.h>
-#include <netinet/tcp.h>
-#include <queue>
-
-typedef int SOCKET;
-#define INVALID_SOCKET -1
-
-#define SleepMiliSec(x)			usleep((x)<<10)
-#endif //WIN32
 
 #endif //__TYPEDEFS_H__
 

--- a/utils.h
+++ b/utils.h
@@ -1,10 +1,11 @@
 #ifndef _UTILS_H__
 #define _UTILS_H__
 
-#include <iostream>
+#include <cstdint>
 #include <fcntl.h>
 #include <gmp.h>
-#include "typedefs.h"
+#include <iostream>
+#include <unistd.h>
 
 #define two_pow(e) (((uint64_t) 1) << (e))
 


### PR DESCRIPTION
* use std:: namespace explicitly
* use forward declarations
* remove unnecessary includes
* move includes to .cpp files if possible
* **hide the MIRACL dependency in the implementation**

So far,  OTExtension (and probably ABY as well) relies on the implicit includes. I will open another PR (or two).