### PR TITLE
Warnings Fix + standard int types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ cmake_install.cmake
 install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake
+
+# VS Code Directory
+.vscode/

--- a/src/ENCRYPTO_utils/crypto/ecc-pk-crypto.cpp
+++ b/src/ENCRYPTO_utils/crypto/ecc-pk-crypto.cpp
@@ -41,7 +41,7 @@ void ecc_field::init(seclvl sp, uint8_t* seed) {
 	fparams = (ecc_fparams*) malloc(sizeof(ecc_fparams));
 	secparam = sp;
 
-	char *ecp = NULL, *ecb = NULL, *ecx = ecx163, *ecy = ecy163, *ecr = ecr163;
+	char *ecx = ecx163, *ecy = ecy163, *ecr = ecr163;
 	fparams->BB = new Big();
 	fparams->BA = new Big();
 	fparams->BP = new Big();
@@ -148,7 +148,7 @@ fe* ecc_field::get_fe() {
 	return new ecc_fe(this);
 }
 
-fe* ecc_field::get_rnd_fe(uint32_t bitlen) {
+fe* ecc_field::get_rnd_fe() {
 	return sample_random_point();
 }
 

--- a/src/ENCRYPTO_utils/crypto/ecc-pk-crypto.h
+++ b/src/ENCRYPTO_utils/crypto/ecc-pk-crypto.h
@@ -52,7 +52,7 @@ class ecc_brickexp;
 class ecc_field: public pk_crypto {
 public:
 	ecc_field(seclvl sp, uint8_t* seed) :
-			pk_crypto(sp, seed) {
+			pk_crypto(sp) {
 		init(sp, seed);
 	}
 	;
@@ -61,7 +61,7 @@ public:
 	num* get_num();
 	num* get_rnd_num(uint32_t bitlen = 0);
 	fe* get_fe();
-	fe* get_rnd_fe(uint32_t bitlen);
+	fe* get_rnd_fe();
 	fe* get_generator();
 	fe* get_rnd_generator();
 	uint32_t get_size();

--- a/src/ENCRYPTO_utils/crypto/gmp-pk-crypto.cpp
+++ b/src/ENCRYPTO_utils/crypto/gmp-pk-crypto.cpp
@@ -105,7 +105,7 @@ num* prime_field::get_rnd_num(uint32_t bitlen) {
 	return ret;
 }
 
-fe* prime_field::get_rnd_fe(uint32_t bitlen) {
+fe* prime_field::get_rnd_fe() {
 	mpz_t val;
 	mpz_init(val);
 	aby_prng(val, mpz_sizeinbase(q, 2) + secparam.ifcbits);

--- a/src/ENCRYPTO_utils/crypto/gmp-pk-crypto.h
+++ b/src/ENCRYPTO_utils/crypto/gmp-pk-crypto.h
@@ -34,7 +34,7 @@ class gmp_brickexp;
 class prime_field: public pk_crypto {
 public:
 	prime_field(seclvl sp, uint8_t* seed) :
-			pk_crypto(sp, seed) {
+			pk_crypto(sp) {
 		init(sp, seed);
 	}
 	;
@@ -43,7 +43,7 @@ public:
 	num* get_num();
 	num* get_rnd_num(uint32_t bitlen = 0);
 	fe* get_fe();
-	fe* get_rnd_fe(uint32_t bitlen);
+	fe* get_rnd_fe();
 	fe* get_generator();
 	fe* get_rnd_generator();
 	num* get_order();

--- a/src/ENCRYPTO_utils/crypto/pk-crypto.h
+++ b/src/ENCRYPTO_utils/crypto/pk-crypto.h
@@ -30,7 +30,7 @@ class brickexp;
 
 class pk_crypto {
 public:
-	pk_crypto(seclvl sp, uint8_t* seed) {
+	pk_crypto(seclvl sp) {
 		fe_bytelen = 0;
 		order = 0;
 		secparam = sp;
@@ -40,7 +40,7 @@ public:
 	virtual num* get_num() = 0;
 	virtual num* get_rnd_num(uint32_t bitlen = 0) = 0;
 	virtual fe* get_fe() = 0;
-	virtual fe* get_rnd_fe(uint32_t bitlen) = 0;
+	virtual fe* get_rnd_fe() = 0;
 	virtual fe* get_generator() = 0;
 	virtual fe* get_rnd_generator() = 0;
 	virtual uint32_t num_byte_size() = 0;

--- a/src/ENCRYPTO_utils/typedefs.h
+++ b/src/ENCRYPTO_utils/typedefs.h
@@ -19,30 +19,21 @@
 #ifndef __TYPEDEFS_H__
 #define __TYPEDEFS_H__
 
-typedef struct SECURITYLEVELS {
-	int statbits;
-	int symbits;
-	int ifcbits;
-	int eccpfbits;
-	int ecckcbits;
-} seclvl;
+#include <cstdint>
 
 typedef int BOOL;
-typedef long LONG;
-
 typedef unsigned char BYTE;
-typedef unsigned short USHORT;
-typedef unsigned int UINT;
-typedef unsigned long ULONG;
-typedef BYTE UINT8_T;
-typedef USHORT UINT16_T;
-typedef UINT UINT32_T;
-typedef unsigned long long UINT64_T;
-typedef long long SINT64_T;
 
-typedef ULONG DWORD;
-typedef UINT64_T UGATE_T;
-typedef UINT64_T REGISTER_SIZE;
+typedef uint64_t UGATE_T;
+typedef uint64_t REGISTER_SIZE;
+
+typedef struct SECURITYLEVELS {
+	uint32_t statbits;
+	uint32_t symbits;
+	uint32_t ifcbits;
+	uint32_t eccpfbits;
+	uint32_t ecckcbits;
+} seclvl;
 
 #define GATE_T_BITS (sizeof(UGATE_T) * 8)
 
@@ -94,4 +85,3 @@ T sub(T a, T b, T m) {
 
 
 #endif //__TYPEDEFS_H__
-


### PR DESCRIPTION
Removes unused variables.
Replaces manual definitions of UINT, etc with standard definitions in <cstdint> (This will require some changes in ABY and OTExtension)