### PR TITLE
Adds a method for creating CBitVector of exact size

### DIFF
--- a/src/ENCRYPTO_utils/cbitvector.cpp
+++ b/src/ENCRYPTO_utils/cbitvector.cpp
@@ -181,6 +181,23 @@ void CBitVector::FillRand(std::size_t bits, crypto* crypt) {
 	crypt->gen_rnd(m_pBits, ceil_divide(bits, 8));
 }
 
+void CBitVector::CreateExact(std::size_t bits) {
+	if (bits == 0)
+		bits = AES_BITS;
+
+	if (m_nByteSize > 0) {
+		free(m_pBits);
+	}
+
+	m_nByteSize = ceil_divide(bits, 8);
+	m_pBits = (BYTE*) calloc(m_nByteSize, sizeof(BYTE));
+	assert(m_pBits != NULL);
+
+	m_nElementLength = 1;
+	m_nNumElements = m_nByteSize;
+	m_nNumElementsDimB = 1;
+}
+
 void CBitVector::Create(std::size_t bits) {
 	if (bits == 0)
 		bits = AES_BITS;

--- a/src/ENCRYPTO_utils/cbitvector.h
+++ b/src/ENCRYPTO_utils/cbitvector.h
@@ -83,6 +83,14 @@ public:
 
 
 	/* Create in bits and bytes */
+	
+	/**
+		This method is used to create the CBitVector with the provided bits. The method creates a bit vector of exactly ceil_divide(bits) size.
+		For example, if bit size provided is 3 after this method is called it will be 8 bits = 1 byte.
+
+		\param  bits	 - It is the number of bits which will be used to allocate the CBitVector with.
+	*/
+	void CreateExact(std::size_t bits);
 
 	/**
 		This method is used to create the CBitVector with the provided bits. The method creates a bit vector with a size close to AES Bitsize.


### PR DESCRIPTION
Creates a `CBitVector` of the given ceiled bit-length. Yet, there was the sole option to create a `CBitVector`  by padding it to the AES block size.