### PR TITLE
Feature request: Make optionally send callers block

### DIFF
--- a/src/ENCRYPTO_utils/channel.cpp
+++ b/src/ENCRYPTO_utils/channel.cpp
@@ -27,9 +27,23 @@ void channel::send(uint8_t* buf, uint64_t nbytes) {
 	assert(m_bSndAlive);
 	m_cSnder->add_snd_task(m_bChannelID, nbytes, buf);
 }
+
+
+void channel::blocking_send(CEvent* eventcaller, uint8_t* buf, uint64_t nbytes) {
+	assert(m_bSndAlive);
+	m_cSnder->add_event_snd_task(eventcaller, m_bChannelID, nbytes, buf);
+	eventcaller->Wait();
+}
+
 void channel::send_id_len(uint8_t* buf, uint64_t nbytes, uint64_t id, uint64_t len) {
 	assert(m_bSndAlive);
 	m_cSnder->add_snd_task_start_len(m_bChannelID, nbytes, buf, id, len);
+}
+
+void channel::blocking_send_id_len(CEvent* eventcaller, uint8_t* buf, uint64_t nbytes, uint64_t id, uint64_t len) {
+	assert(m_bSndAlive);
+	m_cSnder->add_event_snd_task_start_len(eventcaller, m_bChannelID, nbytes, buf, id, len);
+	eventcaller->Wait();
 }
 
 //buf needs to be freed, data contains the payload

--- a/src/ENCRYPTO_utils/channel.h
+++ b/src/ENCRYPTO_utils/channel.h
@@ -26,7 +26,12 @@ public:
 	~channel();
 
 	void send(uint8_t* buf, uint64_t nbytes);
+
+	void blocking_send(CEvent* eventcaller, uint8_t* buf, uint64_t nbytes);
+
 	void send_id_len(uint8_t* buf, uint64_t nbytes, uint64_t id, uint64_t len);
+
+	void blocking_send_id_len(CEvent* eventcaller, uint8_t* buf, uint64_t nbytes, uint64_t id, uint64_t len);
 
 	//buf needs to be freed, data contains the payload
 	uint8_t* blocking_receive_id_len(uint8_t** data, uint64_t* id, uint64_t* len);

--- a/src/ENCRYPTO_utils/sndthread.h
+++ b/src/ENCRYPTO_utils/sndthread.h
@@ -29,8 +29,11 @@ public:
 
 	void add_snd_task_start_len(uint8_t channelid, uint64_t sndbytes, uint8_t* sndbuf, uint64_t startid, uint64_t len);
 
+	void add_event_snd_task_start_len(CEvent* eventcaller, uint8_t channelid, uint64_t sndbytes, uint8_t* sndbuf, uint64_t startid, uint64_t len);
 
 	void add_snd_task(uint8_t channelid, uint64_t sndbytes, uint8_t* sndbuf);
+
+	void add_event_snd_task(CEvent* eventcaller, uint8_t channelid, uint64_t sndbytes, uint8_t* sndbuf);
 
 	void signal_end(uint8_t channelid);
 
@@ -42,6 +45,7 @@ private:
 	struct snd_task {
 		uint8_t channelid;
 		std::vector<uint8_t> snd_buf;
+		CEvent* eventcaller;
 	};
 
 	void push_task(std::unique_ptr<snd_task> task);


### PR DESCRIPTION
Adds a feature which lets a callback wait if the blocking_send method instead of the send method of the channel class is called.

It would be a nice feature since then the communication statistics in the ABY framework could be done correctly then.