### PR TITLE
Graycode reimplementation and ecclvl cmake change

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(encrypto_utils
     ${PROJECT_NAME}/thread.cpp
     ${PROJECT_NAME}/timer.cpp
     ${PROJECT_NAME}/utils.cpp
+    ${PROJECT_NAME}/graycode.cpp
 )
 add_library(ENCRYPTO_utils::encrypto_utils ALIAS encrypto_utils)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,13 +25,17 @@ add_library(ENCRYPTO_utils::encrypto_utils ALIAS encrypto_utils)
 
 target_compile_features(encrypto_utils PUBLIC cxx_std_17)
 target_compile_options(encrypto_utils PRIVATE "-Wall" "-Wextra")
-#Maybe it is better to create a ecc-pk-crypti.h.in file, since the ecclvl is only needed there
-target_compile_definitions(encrypto_utils PUBLIC ECCLVL=${ecclvl})
+
+configure_file (
+    "${CMAKE_CURRENT_SOURCE_DIR}/ENCRYPTO_utils/cmake_constants.h.in"
+    "${PROJECT_BINARY_DIR}/include/cmake_constants.h"
+)
 
 target_include_directories(encrypto_utils
     PUBLIC
         $<INSTALL_INTERFACE:include>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
 )
 
 

--- a/src/ENCRYPTO_utils/cmake_constants.h.in
+++ b/src/ENCRYPTO_utils/cmake_constants.h.in
@@ -1,0 +1,2 @@
+//the security parameter for public crypto
+#define ECCLVL @ecclvl@

--- a/src/ENCRYPTO_utils/constants.h
+++ b/src/ENCRYPTO_utils/constants.h
@@ -21,6 +21,7 @@
 
 #include "typedefs.h"
 #include <cstdint>
+#include <cmake_constants.h>
 
 #define BATCH
 //#define FIXED_KEY_AES_HASHING

--- a/src/ENCRYPTO_utils/graycode.cpp
+++ b/src/ENCRYPTO_utils/graycode.cpp
@@ -1,0 +1,45 @@
+/**
+ \file 		graycode.cpp
+ \author 	Martin Kromm<martin.kromm@stud.tu-darmstadt.de>
+ \copyright	ABY - A Framework for Efficient Mixed-protocol Secure Two-party Computation
+			Copyright (C) 2019 ENCRYPTO Group, TU Darmstadt
+			This program is free software: you can redistribute it and/or modify
+            it under the terms of the GNU Lesser General Public License as published
+            by the Free Software Foundation, either version 3 of the License, or
+            (at your option) any later version.
+            ABY is distributed in the hope that it will be useful,
+            but WITHOUT ANY WARRANTY; without even the implied warranty of
+            MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+            GNU Lesser General Public License for more details.
+            You should have received a copy of the GNU Lesser General Public License
+            along with this program. If not, see <http://www.gnu.org/licenses/>.
+ \brief		Gray-Code implementation
+ */
+
+#include "./graycode.h"
+#include <stdlib.h>
+
+uint32_t* BuildGrayCode(uint32_t length) {
+	uint32_t* gray_code = (uint32_t*) malloc(sizeof(uint32_t) * length);
+	for(uint32_t i = 0; i < length; ++i) {
+		gray_code[i] = i ^ (i >> 1);
+	}
+	return gray_code;
+}
+
+uint32_t* BuildGrayCodeIncrement(uint32_t length) {
+	uint32_t* gray_code_increment = (uint32_t*) malloc(sizeof(uint32_t) * length);
+	for(uint32_t i = 0; i < length; ++i) {
+		gray_code_increment[i] = 0;
+	}
+	uint32_t length_inc = 2;
+	while(length_inc < length) {
+		uint32_t length_count = length_inc - 1;
+		while(length_count <= length) {
+			(gray_code_increment[length_count])++;
+			length_count += length_inc;
+		}
+		length_inc = length_inc << 1;
+	}
+	return gray_code_increment;
+}

--- a/src/ENCRYPTO_utils/graycode.h
+++ b/src/ENCRYPTO_utils/graycode.h
@@ -1,0 +1,22 @@
+/**
+ \file 		graycode.h
+ \author 	Martin Kromm<martin.kromm@stud.tu-darmstadt.de>
+ \copyright	ABY - A Framework for Efficient Mixed-protocol Secure Two-party Computation
+			Copyright (C) 2019 ENCRYPTO Group, TU Darmstadt
+			This program is free software: you can redistribute it and/or modify
+            it under the terms of the GNU Lesser General Public License as published
+            by the Free Software Foundation, either version 3 of the License, or
+            (at your option) any later version.
+            ABY is distributed in the hope that it will be useful,
+            but WITHOUT ANY WARRANTY; without even the implied warranty of
+            MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+            GNU Lesser General Public License for more details.
+            You should have received a copy of the GNU Lesser General Public License
+            along with this program. If not, see <http://www.gnu.org/licenses/>.
+ \brief		Gray-Code implementation
+ */
+
+#include <stdint.h>
+
+uint32_t* BuildGrayCode(uint32_t length);
+uint32_t* BuildGrayCodeIncrement(uint32_t length);


### PR DESCRIPTION
- Reimplemented the graycode needed for the LowMC example
- Changed the way the definition of the ecclvl level looks like. Not it is in a file which is changed by cmake