### PR TITLE
fix relic dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,8 @@ set_target_properties(RELIC::relic PROPERTIES
 	INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/extern/relic/include;${CMAKE_CURRENT_SOURCE_DIR}/extern/relic/include/low;${CMAKE_CURRENT_BINARY_DIR}/extern/relic/include"
 )
 
+target_link_libraries(RELIC::relic INTERFACE relic_s)
+
 add_subdirectory(src)
 
 if(ENCRYPTO_UTILS_BUILD_TESTS)


### PR DESCRIPTION
ENCRYPTO_utils ignores the relic_s target if the `encrypto_utils` target is explicitly specified, e.g., as `cmake --build . --target encrypto_utils`. Adding the correct relic target name as dependency for the imported `RELIC::relic` target fixes this problem.