### PR TITLE
Parallelization bug #23 and cmake_constant_file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,9 @@ elseif(NOT RELIC_FOUND AND NOT TARGET RELIC::relic)
 	endif()
 endif()
 
-set(ecclvl 251) #set this for the ecc security level
+#relic library configuration with customizable parameters (you are likely wanting to change them)
+set(FB_POLYN "251" CACHE STRING "security level of the ecc binary curve in relic") # set this to change the elliptic curve security parameter
+set(MULTI "PTHREAD" CACHE STRING "Multithreading interface") #set this to "" in case your operating system doesn_t support the __thread keyword and pthread
 
 #relic library configuration
 set(DEBUG off CACHE BOOL "Build relic with debugging support")
@@ -37,7 +39,6 @@ set(CHECK off CACHE BOOL "Build relic with error-checking support")
 set(ALIGN "16" CACHE STRING "Relic align")
 set(ARCH "X64" CACHE STRING "Architecture to be used in relic")
 set(ARITH "curve2251-sse" CACHE STRING "arithmetic utils used in relic")
-set(FB_POLYN ${ecclvl} CACHE INTEGER "security level of the ecc binary curve in relic")
 set(FB_METHD "INTEG;INTEG;QUICK;QUICK;QUICK;QUICK;LOWER;SLIDE;QUICK" CACHE STRING "Methods for fb in relic")
 set(FB_PRECO on CACHE BOOl "fb preco for relic")
 set(FB_SQRTF off CACHE BOOL "sqrtf for relic")

--- a/src/ENCRYPTO_utils/cmake_constants.h.in
+++ b/src/ENCRYPTO_utils/cmake_constants.h.in
@@ -1,2 +1,14 @@
+#ifndef CMAKE_CONSTANTS_H_
+
 //the security parameter for public crypto
-#define ECCLVL @ecclvl@
+#define ECCLVL @FB_POLYN@
+
+//the support of the __thread keyword and pthreads
+#cmakedefine MULTI @MULTI@
+#if defined(MULTI)
+#if MULTI == PTHREAD
+    #define TRHEADSYNC_ENABLED
+#endif
+#endif
+
+#endif //CMAKE_CONSTANTS_H_

--- a/src/ENCRYPTO_utils/crypto/ecc-pk-crypto.h
+++ b/src/ENCRYPTO_utils/crypto/ecc-pk-crypto.h
@@ -34,7 +34,16 @@ class ecc_num;
 class ecc_fe;
 class ecc_brickexp;
 
+//The __thread keyword is implementation dependent and therefore
+//it is potentionally dangerous to use this keyword.
+//If the code doesn't compile with your compiler change
+//the MULTI keyword in the cmake configuration to an empty string
+//to disable thread local storage
+#ifdef TRHEADSYNC_ENABLED
+static __thread std::mutex relic_mutex;
+#else
 static std::mutex relic_mutex;
+#endif
 
 class ecc_field: public pk_crypto {
 public:


### PR DESCRIPTION
- Fixed the parallelization bug #23 which prevents possible parallelization due to the introduced mutex. Now the mutex is also protected using __thread but since it is implementation dependent the flag can be easily disabled
- Changed the introduction of constants from CMAKE to an extra file cmake_constants.h.in